### PR TITLE
Use stored keys and configurable key encryption keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ the Korma `defentity` macro.
 
 Korma Encrypted also requires a separate database table to include encryption keys and is configured with a key encryption key.
 Additionally korma-encrypted will create a relation between the table with encrypted columns and a table assumed to be
-called `encryption_keys`.
+called `data_encryption_keys`. You can generate an encrypted data encryption key with the `generated-and-save-data-encryption-key` function,
+also passing it your key encryption key and optionally the database to insert into.
 
 ```clojure
 (require [korma.core :as korma]
          [korma-encrypted.core :refer [encrypted-fields]])
 
 (def key-encryption-key "This is not secure, don't do this for real.")
+
+(generate-and-save-data-encryption-key key-encryption-key)
 
 (defentity credit-card
   (encrypted-fields key-encryption-key :number :expiration-date-month :expiration-date-year))

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the Korma `defentity` macro.
 
 Korma Encrypted also requires a separate database table to include encryption keys and is configured with a key encryption key.
 Additionally korma-encrypted will create a relation between the table with encrypted columns and a table assumed to be
-called `data_encryption_keys`. You can generate an encrypted data encryption key with the `generated-and-save-data-encryption-key` function,
+called `data_encryption_keys`. You can generate an encrypted data encryption key with the `generate-and-save-data-encryption-key` function,
 also passing it your key encryption key and optionally the database to insert into.
 
 ```clojure

--- a/src/korma_encrypted/core.clj
+++ b/src/korma_encrypted/core.clj
@@ -1,5 +1,6 @@
 (ns korma-encrypted.core
   (:require [korma.core :as korma]
+            [korma.db]
             [byte-streams :as bs]
             [clojure.data.codec.base64 :as b64]
             [korma-encrypted.crypto :refer :all])
@@ -11,6 +12,17 @@
 
 (korma/defentity data-encryption-keys
   (korma/table :data_encryption_keys))
+
+(defn generate-and-save-data-encryption-key
+  ([key-encryption-key]
+    (let [data-encryption-key (secretkey->str (SecretKey/generate))
+          encrypted-data-encryption-key (encrypt-value data-encryption-key (SecretBox. (str->secretkey key-encryption-key)))]
+      (korma/insert data-encryption-keys
+                    (korma/values {:data_encryption_key encrypted-data-encryption-key}))))
+
+  ([key-encryption-key db]
+    (korma.db/with-db db
+      (generate-and-save-data-encryption-key key-encryption-key))))
 
 (defn tap-class [x] (println x ) (println (class x)) x)
 (defn tap [x] (println x) x)

--- a/src/korma_encrypted/core.clj
+++ b/src/korma_encrypted/core.clj
@@ -39,9 +39,11 @@
       first
       :data_encryption_key))
 
-(defn- get-data-box [key-service]
-  (let [data-encryption-key (decrypt key-service (get-encrypted-data-encryption-key))]
-    (SecretBox. (str->secretkey data-encryption-key))))
+(def get-data-box
+  (memoize
+    (fn [key-service]
+      (let [data-encryption-key (decrypt key-service (get-encrypted-data-encryption-key))]
+        (SecretBox. (str->secretkey data-encryption-key))))))
 
 (defn prepare-values [field key-service values]
   (let [box (get-data-box key-service)]

--- a/src/korma_encrypted/core.clj
+++ b/src/korma_encrypted/core.clj
@@ -1,55 +1,52 @@
 (ns korma-encrypted.core
   (:require [korma.core :as korma]
             [byte-streams :as bs]
-            [clojure.data.codec.base64 :as b64])
+            [clojure.data.codec.base64 :as b64]
+            [korma-encrypted.crypto :refer :all])
   (:import [com.jtdowney.chloride.keys SecretKey]
            [org.bouncycastle.jce.provider BouncyCastleProvider]
            [com.jtdowney.chloride.boxes SecretBox]))
 
 (java.security.Security/addProvider (BouncyCastleProvider.))
 
-(korma/defentity encryption-keys
-  (korma/table :encryption_keys))
-
-(def secret-key (SecretKey/generate))
-(def box (SecretBox. secret-key))
-
-(defn encrypted-name [field]
-  (keyword (str "encrypted_" (name field))))
+(korma/defentity data-encryption-keys
+  (korma/table :data_encryption_keys))
 
 (defn tap-class [x] (println x ) (println (class x)) x)
-
-(defn decrypt-value [value]
-  (when value
-    (let [as-bytes (b64/decode (.getBytes value))
-          decrypted-bytes (.decrypt box as-bytes)]
-      (-> decrypted-bytes bs/to-string))))
-
-(defn encrypt-value [value]
-  (when value
-    (let [as-bytes (bs/to-byte-array value)
-          encrypted (.encrypt box as-bytes)]
-      (-> encrypted b64/encode (String.)))))
-
 (defn tap [x] (println x) x)
 
-(defn prepare-values [field values]
-  (if (contains? values field)
-    (let [unencrypted-value (field values)]
-      (-> values
-          (assoc (encrypted-name field) (encrypt-value unencrypted-value))
-          (dissoc field)))
-    values))
+(defn- encrypted-name [field]
+  (keyword (str "encrypted_" (name field))))
 
-(defn transform-values [field values]
+(defn- get-encrypted-data-encryption-key []
+  (-> (korma/select data-encryption-keys)
+      first
+      :data_encryption_key))
+
+(defn- get-data-box [key-encryption-key]
+  (let [key-encryption-box (SecretBox. (str->secretkey key-encryption-key))
+        data-encryption-key (decrypt-value (get-encrypted-data-encryption-key) key-encryption-box)]
+    (SecretBox. (str->secretkey data-encryption-key))))
+
+(defn prepare-values [field key-encryption-key values]
+  (let [box (get-data-box key-encryption-key)]
+    (if (contains? values field)
+      (let [unencrypted-value (field values)]
+        (-> values
+            (assoc (encrypted-name field) (encrypt-value unencrypted-value box))
+            (dissoc field)))
+      values)))
+
+(defn transform-values [field key-encryption-key values]
   (let [encrypted-field-name (encrypted-name field)
-        encrypted-value (get values encrypted-field-name)]
+        encrypted-value (get values encrypted-field-name)
+        box (get-data-box key-encryption-key)]
     (-> values
-        (assoc field (decrypt-value encrypted-value))
+        (assoc field (decrypt-value encrypted-value box))
         (dissoc encrypted-field-name))))
 
-(defn encrypted-field [ent field]
+(defn encrypted-field [ent field key-encryption-key]
   (-> ent
-      (korma/prepare (partial prepare-values field))
-      (korma/transform (partial transform-values field))
-      (korma/rel (var encryption-keys) :belongs-to nil)))
+      (korma/prepare (partial prepare-values field key-encryption-key))
+      (korma/transform (partial transform-values field key-encryption-key))
+      (korma/rel (var data-encryption-keys) :belongs-to nil)))

--- a/src/korma_encrypted/crypto.clj
+++ b/src/korma_encrypted/crypto.clj
@@ -1,0 +1,30 @@
+(ns korma-encrypted.crypto
+  (:require [byte-streams :as bs]
+            [clojure.data.codec.base64 :as b64])
+  (:import [com.jtdowney.chloride.keys SecretKey]
+           [org.bouncycastle.jce.provider BouncyCastleProvider]
+           [com.jtdowney.chloride.boxes SecretBox]))
+
+(defn secretkey->str [encryption-key]
+  (-> encryption-key
+      .getBytes
+      b64/encode
+      String.))
+
+(defn str->secretkey [encryption-key]
+  (-> encryption-key
+      .getBytes
+      b64/decode
+      SecretKey.))
+
+(defn decrypt-value [value box]
+  (when value
+    (let [as-bytes (b64/decode (.getBytes value))
+          decrypted-bytes (.decrypt box as-bytes)]
+      (-> decrypted-bytes bs/to-string))))
+
+(defn encrypt-value [value box]
+  (when value
+    (let [as-bytes (bs/to-byte-array value)
+          encrypted (.encrypt box as-bytes)]
+      (-> encrypted b64/encode (String.)))))

--- a/test/korma_encrypted/core_test.clj
+++ b/test/korma_encrypted/core_test.clj
@@ -26,9 +26,12 @@
                             :port db-port
                             :password "mysecretpassword"}))
 
-(def key-encryption-key (secretkey->str (SecretKey/generate))) ; this should really come from key service
-(def data-encryption-key (secretkey->str (SecretKey/generate)))
-(def encrypted-data-encryption-key (encrypt-value data-encryption-key (SecretBox. (str->secretkey key-encryption-key))))
+(deftype ChlorideKeyService [a-key]
+  KeyService
+  (encrypt [self data] (encrypt-value data (SecretBox. a-key)))
+  (decrypt [self data] (decrypt-value data (SecretBox. a-key))))
+
+(def key-service (ChlorideKeyService. (SecretKey/generate)))
 
 (use-fixtures :once
   (fn [f]
@@ -50,14 +53,14 @@
        (tap (sql/create-table-ddl "data_encryption_keys"
                                   [:id "serial primary key"]
                                   [:data_encryption_key "text"])))
-       (generate-and-save-data-encryption-key key-encryption-key spec)
+       (generate-and-save-data-encryption-key key-service spec)
     (db/defdb pg-db spec)
     (db/default-connection pg-db)
     (f)))
 
 (korma/defentity credit-card-with-encrypted-fields
   (korma/table :credit_cards)
-  (encrypted-field :number key-encryption-key))
+  (encrypted-field :number key-service))
 
 (deftest test-round-trip
   (let [stored (korma/insert credit-card-with-encrypted-fields
@@ -74,35 +77,35 @@
 
 (deftest test-prepare-values-replaces-field-name-with-encrypted-field-name
   (let [values {:number "41111111111111"}
-        prepared-values (prepare-values :number key-encryption-key values)]
+        prepared-values (prepare-values :number key-service values)]
     (is (contains? prepared-values :encrypted_number))
     (is (not (contains? prepared-values :number)))))
 
 (deftest test-prepare-values-set-field-to-null
   (let [values {:number nil}
-        prepared (prepare-values :number key-encryption-key values)]
+        prepared (prepare-values :number key-service values)]
     (is (= {:encrypted_number nil} prepared))))
 
 (deftest test-prepare-values-without-specifying-fields
   (let [values {:name "Bob Dole"}
-        prepared (prepare-values :number key-encryption-key values)]
+        prepared (prepare-values :number key-service values)]
     (is (= {:name "Bob Dole"} prepared))))
 
 (deftest test-transform-values-replaces-encrypted-field-with-field-name
   (let [values {:number "4111"}
-        prepared-values (prepare-values :number key-encryption-key values)
-        transformed-values (transform-values :number key-encryption-key prepared-values)]
+        prepared-values (prepare-values :number key-service values)
+        transformed-values (transform-values :number key-service prepared-values)]
     (is (contains? transformed-values :number))
     (is (not (contains? transformed-values :encrypted_number)))
     (is (= transformed-values values))))
 
 (deftest test-transform-values-with-null-column
   (let [values {:encrypted_number nil}
-        transformed-values (transform-values :number key-encryption-key values)]
+        transformed-values (transform-values :number key-service values)]
     (is (= nil (:number values)))))
 
 (deftest test-generate-and-save-data-encryption-key
-  (let [saved-key (generate-and-save-data-encryption-key key-encryption-key)
+  (let [saved-key (generate-and-save-data-encryption-key key-service)
         stored (first (korma/select data-encryption-keys
                              (korma/where {:id (:id saved-key)})))]
     (is (= (:data_encryption_key stored) (:data_encryption_key saved-key)))))

--- a/test/korma_encrypted/core_test.clj
+++ b/test/korma_encrypted/core_test.clj
@@ -46,10 +46,11 @@
                                   [:id "serial primary key"]
                                   [:name "text"]
                                   [:encrypted_number "text"]))
+
        (tap (sql/create-table-ddl "data_encryption_keys"
                                   [:id "serial primary key"]
                                   [:data_encryption_key "text"])))
-
+       (generate-and-save-data-encryption-key key-encryption-key spec)
     (db/defdb pg-db spec)
     (db/default-connection pg-db)
     (f)))
@@ -57,8 +58,6 @@
 (korma/defentity credit-card-with-encrypted-fields
   (korma/table :credit_cards)
   (encrypted-field :number key-encryption-key))
-
-(generate-and-save-data-encryption-key key-encryption-key spec)
 
 (deftest test-round-trip
   (let [stored (korma/insert credit-card-with-encrypted-fields


### PR DESCRIPTION
Now korma-encrypted will read stored keys from the database (currently just the first one available for all encrypted fields), use the key-encryption-key passed to `encrypted-field` to decrypt it, and use then use the decrypted data-encryption-key to encrypte/decrypt data.  Also add the ability for the host application to generate an encrypted encryption key on app setup.  We tested all this out in decisions and it's working!

Lots of refactoring/organization changes too.
