### PR TITLE
Add support for multiple data encryption keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ also passing it your key encryption key and optionally the database to insert in
   (encrypted-fields key-encryption-key :number :expiration-date-month :expiration-date-year))
 ```
 
+When performing updates on entities with encrypted fields, use `korma-encrypted/update-encrypted-entity` instead of the standard `korma/update` function.  This ensures data encryption key foriegn keys stored on encrypted entities are preserved on updates.
+
+```clojure
+
+(update-encrypted-entity credit-card-with-encrypted-fields
+                         primary-key-of-card-to-update
+                         map-of-fields-to-update)
+```
+
 ## License
 
 Copyright © 2015 William Dix

--- a/src/korma_encrypted/core.clj
+++ b/src/korma_encrypted/core.clj
@@ -35,8 +35,10 @@
   (keyword (str "encrypted_" (name field))))
 
 (defn- get-encrypted-data-encryption-key [pk]
-  (:data_encryption_key (first (korma/select data-encryption-keys
-                               (korma/where {:pk pk})))))
+  (-> (korma/select data-encryption-keys
+                    (korma/where {:pk pk}))
+      first
+      :data_encryption_key))
 
 (defn- most-recent-data-encryption-key []
   (first (korma/select data-encryption-keys
@@ -51,9 +53,11 @@
 (defn update-encrypted-entity [ent pk fields]
   (let [record (first (korma/select ent (korma/where {:pk pk})))
         updated-values (assoc fields :data_encryption_key_fk (:data_encryption_key_fk record))]
-    (korma/update ent
-                  (korma/set-fields updated-values)
-                  (korma/where {:pk pk}))))
+    (if record
+      (korma/update ent
+                    (korma/set-fields updated-values)
+                    (korma/where {:pk pk}))
+      0)))
 
 (defn- prepare-encrypted-fields [field key-service values]
   (if (contains? values field)

--- a/src/korma_encrypted/core.clj
+++ b/src/korma_encrypted/core.clj
@@ -34,32 +34,54 @@
 (defn- encrypted-name [field]
   (keyword (str "encrypted_" (name field))))
 
-(defn- get-encrypted-data-encryption-key []
-  (-> (korma/select data-encryption-keys)
-      first
-      :data_encryption_key))
+(defn- get-encrypted-data-encryption-key [pk]
+  (:data_encryption_key (first (korma/select data-encryption-keys
+                               (korma/where {:pk pk})))))
 
-(def get-data-box
+(defn- most-recent-data-encryption-key []
+  (first (korma/select data-encryption-keys
+                       (korma/order :pk :desc))))
+
+(def get-data-encryption-box
   (memoize
-    (fn [key-service]
-      (let [data-encryption-key (decrypt key-service (get-encrypted-data-encryption-key))]
+    (fn [key-service pk]
+      (let [data-encryption-key (decrypt key-service (get-encrypted-data-encryption-key pk))]
         (SecretBox. (str->secretkey data-encryption-key))))))
 
-(defn prepare-values [field key-service values]
-  (let [box (get-data-box key-service)]
-    (if (contains? values field)
-      (let [unencrypted-value (field values)]
+(defn update-encrypted-entity [ent pk fields]
+  (let [record (first (korma/select ent (korma/where {:pk pk})))
+        updated-values (assoc fields :data_encryption_key_fk (:data_encryption_key_fk record))]
+    (korma/update ent
+                  (korma/set-fields updated-values)
+                  (korma/where {:pk pk}))))
+
+(defn- prepare-encrypted-fields [field key-service values]
+  (if (contains? values field)
+    (let [data-encryption-key-fk (:data_encryption_key_fk values)
+          box (get-data-encryption-box key-service data-encryption-key-fk)
+          unencrypted-value (field values)]
         (-> values
             (assoc (encrypted-name field) (encrypt-value unencrypted-value box))
             (dissoc field)))
-      values)))
+    values))
+
+(defn prepare-encryption-key-field [values]
+  (if (not (contains? values :data_encryption_key_fk))
+    (assoc values :data_encryption_key_fk (:pk (most-recent-data-encryption-key)))
+    values))
+
+(defn prepare-values [field key-service values]
+  (prepare-encrypted-fields field key-service (prepare-encryption-key-field values)))
 
 (defn transform-values [field key-service values]
   (let [encrypted-field-name (encrypted-name field)
-        encrypted-value (get values encrypted-field-name)
-        box (get-data-box key-service)]
+        encrypted-value (get values encrypted-field-name)]
     (-> values
-        (assoc field (decrypt-value encrypted-value box))
+        (assoc field
+               (when encrypted-value
+                 (let [data-encryption-key-fk (:data_encryption_key_fk values)
+                       box (get-data-encryption-box key-service data-encryption-key-fk)]
+                    (decrypt-value encrypted-value box))))
         (dissoc encrypted-field-name))))
 
 (defn encrypted-field [ent field key-service]

--- a/test/korma_encrypted/core_test.clj
+++ b/test/korma_encrypted/core_test.clj
@@ -46,14 +46,15 @@
     (sql/db-do-commands
        spec
        (tap (sql/create-table-ddl "credit_cards"
-                                  [:id "serial primary key"]
+                                  [:pk "serial primary key"]
                                   [:name "text"]
+                                  [:data_encryption_key_fk "integer"]
                                   [:encrypted_number "text"]))
 
        (tap (sql/create-table-ddl "data_encryption_keys"
-                                  [:id "serial primary key"]
+                                  [:pk "serial primary key"]
                                   [:data_encryption_key "text"])))
-       (generate-and-save-data-encryption-key key-service spec)
+       (def initial-data-encryption-key (generate-and-save-data-encryption-key key-service spec))
     (db/defdb pg-db spec)
     (db/default-connection pg-db)
     (f)))
@@ -66,14 +67,37 @@
   (let [stored (korma/insert credit-card-with-encrypted-fields
                              (korma/values {:number "4111111111111111"}))
         retrieved (first (korma/select credit-card-with-encrypted-fields
-                                       (korma/where {:id (:id stored)})))]
+                                       (korma/where {:pk (:pk stored)})))]
     (is (= "4111111111111111" (:number retrieved)))))
 
 (deftest test-raw-values-are-not-stored
   (let [stored (korma/insert credit-card-with-encrypted-fields
                              (korma/values {:number "4111111111111111"}))
-        raw-retrieved (first (korma/exec-raw ["SELECT * from credit_cards WHERE id = ?" [(:id stored)]] :results))]
+        raw-retrieved (first (korma/exec-raw ["SELECT * from credit_cards WHERE pk = ?" [(:pk stored)]] :results))]
     (is (not (= "4111111111111111" (:encrypted_number raw-retrieved))))))
+
+(deftest test-newest-data-encryption-key-fk-is-stored-on-insert
+  (let [new-data-encryption-key (generate-and-save-data-encryption-key key-service)
+        stored (korma/insert credit-card-with-encrypted-fields
+                             (korma/values {:number "4111111111111111"}))
+        retrieved (first (korma/select credit-card-with-encrypted-fields
+                                       (korma/where {:pk (:pk stored)})))]
+    (is (contains? retrieved :data_encryption_key_fk))
+    (is (= (:data_encryption_key_fk retrieved) (:pk new-data-encryption-key)))))
+
+(deftest test-old-data-encryption-key-is-not-overridden-on-update
+  (let [old-data-encryption-key (generate-and-save-data-encryption-key key-service)
+        stored (korma/insert credit-card-with-encrypted-fields
+                             (korma/values {:number "4111111111111111" :name "Bob Dole"}))
+        new-data-encryption-key (generate-and-save-data-encryption-key key-service)
+        updated (update-encrypted-entity credit-card-with-encrypted-fields
+                                         (:pk stored)
+                                         {:number "3222222222222222"})
+        retrieved (first (korma/select credit-card-with-encrypted-fields
+                                       (korma/where {:pk (:pk stored)})))]
+    (is (= (:name retrieved) "Bob Dole"))
+    (is (= (:number retrieved) "3222222222222222"))
+    (is (= (:data_encryption_key_fk retrieved) (:pk old-data-encryption-key)))))
 
 (deftest test-prepare-values-replaces-field-name-with-encrypted-field-name
   (let [values {:number "41111111111111"}
@@ -81,15 +105,29 @@
     (is (contains? prepared-values :encrypted_number))
     (is (not (contains? prepared-values :number)))))
 
+(deftest test-prepare-encryption-key-field-adds-newest-encryption-key-fk
+  (let [values {:number "41111111111111"}
+        encryption-key-fk (:pk (generate-and-save-data-encryption-key key-service))
+        prepared-values (prepare-encryption-key-field values)]
+    (is (contains? prepared-values :data_encryption_key_fk))
+    (is (= (:data_encryption_key_fk prepared-values) encryption-key-fk))))
+
+(deftest test-prepare-encrpytion-key-fk-ignores-an-existing-encrpytion-key
+  (let [values {:number "31111111111111" :data_encryption_key_fk 1}
+        new-encryption-key-fk (:pk (generate-and-save-data-encryption-key key-service))
+        prepared-values (prepare-encryption-key-field values)]
+    (is (not (= (:data_encryption_key_fk prepared-values) new-encryption-key-fk)))))
+
 (deftest test-prepare-values-set-field-to-null
   (let [values {:number nil}
         prepared (prepare-values :number key-service values)]
-    (is (= {:encrypted_number nil} prepared))))
+    (is (= (:encrypted_number prepared) nil))))
 
 (deftest test-prepare-values-without-specifying-fields
   (let [values {:name "Bob Dole"}
         prepared (prepare-values :number key-service values)]
-    (is (= {:name "Bob Dole"} prepared))))
+    (is (= (:name prepared) "Bob Dole"))
+    (is (not (contains? values :encrypted_number)))))
 
 (deftest test-transform-values-replaces-encrypted-field-with-field-name
   (let [values {:number "4111"}
@@ -97,15 +135,28 @@
         transformed-values (transform-values :number key-service prepared-values)]
     (is (contains? transformed-values :number))
     (is (not (contains? transformed-values :encrypted_number)))
-    (is (= transformed-values values))))
+    (is (= (:number transformed-values) "4111"))))
+
+(deftest test-transform-handles-nil-data-encryption-key-fk
+  (let [values {:encrypted_number nil :data_encryption_key_fk nil}
+        transformed-values (transform-values :number key-service values)]
+    (is (contains? transformed-values :number))
+    (is (= (:number transformed-values) nil))))
+
+(deftest test-transform-values-uses-correct-encryption-key
+  (let [values {:number "4111"}
+        prepared-values (prepare-values :number key-service values)
+        new-encryption-key (generate-and-save-data-encryption-key key-service)
+        transformed-values (transform-values :number key-service prepared-values)]
+    (is (= (:number transformed-values) "4111"))))
 
 (deftest test-transform-values-with-null-column
-  (let [values {:encrypted_number nil}
+  (let [values {:encrypted_number nil :data_encryption_key_fk (:pk initial-data-encryption-key)}
         transformed-values (transform-values :number key-service values)]
     (is (= nil (:number values)))))
 
 (deftest test-generate-and-save-data-encryption-key
   (let [saved-key (generate-and-save-data-encryption-key key-service)
         stored (first (korma/select data-encryption-keys
-                             (korma/where {:id (:id saved-key)})))]
+                             (korma/where {:pk (:pk saved-key)})))]
     (is (= (:data_encryption_key stored) (:data_encryption_key saved-key)))))

--- a/test/korma_encrypted/core_test.clj
+++ b/test/korma_encrypted/core_test.clj
@@ -99,6 +99,12 @@
     (is (= (:number retrieved) "3222222222222222"))
     (is (= (:data_encryption_key_fk retrieved) (:pk old-data-encryption-key)))))
 
+(deftest test-updating-non-existent-record
+  (let [updated (update-encrypted-entity credit-card-with-encrypted-fields
+                                         -1
+                                         {:number "3222222222222222"})]
+    (is (= updated 0))))
+
 (deftest test-prepare-values-replaces-field-name-with-encrypted-field-name
   (let [values {:number "41111111111111"}
         prepared-values (prepare-values :number key-service values)]


### PR DESCRIPTION
 by storing `data_encryption_key_fk` on encrypted records.

Also adds that annoying API change we spoke about on necessary for updates, see the readme for how it works.  Is there a way we can warn the user if they attempt to update an encrypted entity with the standard korma/update function? doing this will blow away their the existing record's encryption_key_fk, unfortunately.
