### PR TITLE
Add key rotation

### DIFF
--- a/test/korma_encrypted/core_test.clj
+++ b/test/korma_encrypted/core_test.clj
@@ -166,3 +166,17 @@
         stored (first (korma/select data-encryption-keys
                              (korma/where {:pk (:pk saved-key)})))]
     (is (= (:data_encryption_key stored) (:data_encryption_key saved-key)))))
+
+(deftest test-key-rotation
+  (let [old-service key-service
+        new-service (ChlorideKeyService. (SecretKey/generate))
+        encrypted-key (get-encrypted-data-encryption-key (:pk initial-data-encryption-key))
+        decrypted-key (decrypt old-service encrypted-key)
+        new-encrypted-key (do
+                            (rotate-key-encryption-keys old-service new-service)
+                            (get-encrypted-data-encryption-key (:pk initial-data-encryption-key)))
+        new-decrypted-key (decrypt new-service new-encrypted-key)]
+      (is (= decrypted-key
+             new-decrypted-key))
+      (is (not (= encrypted-key
+                  new-encrypted-key)))))


### PR DESCRIPTION
@NickTomlin @SeanHurley  @wjdix 

This adds key rotation functionality.  The host application will have to figure out the best way to run the function, because we don't have a de-facto way to do key service configuration for korma-encrypted yet, but we've tested this and created a script in decisions to utilize it.
