### PR TITLE
Add support for zero-downtime key-encryption-key rotation

### DIFF
--- a/src/korma_encrypted/core.clj
+++ b/src/korma_encrypted/core.clj
@@ -13,13 +13,6 @@
   (decrypt [self data])
   (encrypt [self data]))
 
-(deftype ErrorCatchingDecryptKeyService [wrapped-service]
-  KeyService
-  (decrypt [_ data] (try (decrypt wrapped-service data)
-                       (catch Exception e data)))
-  (encrypt [_ data] (try (encrypt wrapped-service data)
-                       (catch Exception e data))))
-
 (defn generate-and-save-data-encryption-key
   ([key-service]
     (let [data-encryption-key (secretkey->str (new-secret-key))
@@ -33,14 +26,13 @@
 
 (defn rotate-key-encryption-keys
   ([old-service new-service]
-   (let [wrapped-old-service (ErrorCatchingDecryptKeyService. old-service)]
-     (korma.db/transaction
-       (doseq [encryption-key (korma/select data-encryption-keys)]
-         (let [decrypted-key (decrypt wrapped-old-service (:data_encryption_key encryption-key))
-               re-encrypted-key (encrypt new-service decrypted-key)]
-           (korma/update data-encryption-keys
-                         (korma/set-fields {:data_encryption_key re-encrypted-key})
-                         (korma/where {:pk (:pk encryption-key)})))))))
+   (korma.db/transaction
+     (doseq [encryption-key (korma/select data-encryption-keys)]
+       (let [decrypted-key (decrypt old-service (:data_encryption_key encryption-key))
+             re-encrypted-key (encrypt new-service decrypted-key)]
+         (korma/update data-encryption-keys
+                       (korma/set-fields {:data_encryption_key re-encrypted-key})
+                       (korma/where {:pk (:pk encryption-key)}))))))
   ([old-service new-service db]
    (korma.db/with-db db
      (rotate-key-encryption-keys old-service new-service))))

--- a/src/korma_encrypted/multi_key_service.clj
+++ b/src/korma_encrypted/multi_key_service.clj
@@ -1,0 +1,22 @@
+(ns korma-encrypted.multi-key-service
+  (:require [korma-encrypted.core :refer :all]))
+
+(defn- try-decrypt [data key-service]
+  (try
+    (decrypt key-service data)
+    (catch Exception e nil)))
+
+(deftype MultiKeyService [key-services]
+  KeyService
+  (encrypt [self data]
+    (encrypt (last key-services) data))
+  (decrypt [self data]
+    (let [result (filter some? (map (partial try-decrypt data) key-services))]
+      (if (seq result)
+        (first result)
+        (throw (RuntimeException. "failed to decrypt with all keys"))))))
+
+(defn multi-key-service [key-services]
+  (if (seq key-services)
+    (MultiKeyService. key-services)
+    (throw (IllegalArgumentException. "key-services must not be empty"))))

--- a/test/korma_encrypted/multi_key_service_test.clj
+++ b/test/korma_encrypted/multi_key_service_test.clj
@@ -1,0 +1,41 @@
+(ns korma-encrypted.multi-key-service-test
+  (:require [clojure.test :refer :all]
+            [korma-encrypted.core :refer :all]
+            [korma-encrypted.crypto :refer :all]
+            [korma-encrypted.multi-key-service :refer :all])
+  (:import [com.jtdowney.chloride.boxes SecretBox]
+           [com.jtdowney.chloride.keys SecretKey]))
+
+(deftype ChlorideKeyService [a-key]
+  KeyService
+  (encrypt [self data] (encrypt-value data (SecretBox. a-key)))
+  (decrypt [self data] (decrypt-value data (SecretBox. a-key))))
+
+(def plaintext "some message")
+
+(def key-service-first (ChlorideKeyService. (SecretKey/generate)))
+(def key-service-last (ChlorideKeyService. (SecretKey/generate)))
+(def key-services (multi-key-service [key-service-first key-service-last]))
+
+(deftest test-empty-multi-key-services-fails
+  (is (thrown? IllegalArgumentException (multi-key-service []))))
+
+(deftest test-encrypts-with-last-key
+  (let [ciphertext (encrypt key-services plaintext)
+        result (decrypt key-service-last ciphertext)]
+    (is (= result plaintext))))
+
+(deftest test-can-decrypt-with-first-key
+  (let [ciphertext (encrypt key-service-first plaintext)
+        result (decrypt key-services ciphertext)]
+    (is (= result plaintext))))
+
+(deftest test-can-decrypt-with-last-key
+  (let [ciphertext (encrypt key-service-last plaintext)
+        result (decrypt key-services ciphertext)]
+    (is (= result plaintext))))
+
+(deftest test-decrypt-fails-if-no-keys-work
+  (let [key-service-other (ChlorideKeyService. (SecretKey/generate))
+        ciphertext (encrypt key-service-other plaintext)]
+    (is (thrown? RuntimeException (decrypt key-services ciphertext)))))


### PR DESCRIPTION
This PR adds support doing a zero-downtime rotation of an app's key encryption key (KEK).

For a zero-downtime KEK rotation, each instance of an app running before the rotation needs to have both the current KEK and the new KEK, so that it'll always have the KEK it needs to decrypt data encryption keys (DEKs) regardless of which KEK is in use at any given moment.

70f04af supports this by adding a `MultiKeyService` implementation of `KeyService`, which delegates encryption and decryption to a list of other `KeyService`s.  It's assumed that the list is ordered from oldest `KeyService` to newest.  `decrypt` tries each `KeyService` until it finds one that succeeds in decrypting the DEK.  `encrypt` uses the last (newest) `KeyService` in the list to encrypt a DEK.  Thus, an app interested in zero-downtime KEK rotation can use a `MultiKeyService` with `KeyService` instances for the old and new KEKs wherever it currently uses a single `KeyService`.

If an app doesn't care about zero-downtime KEK rotation, no changes are needed; it can keep using whatever implementation of `KeyService` it's already using.

8c5f494 fixes a data corruption bug in `rotate-key-encryption-keys` where if decryption of a DEK failed (e.g. if you called it with the wrong `old-service`), the function would silently swallow the error and encrypt the already-encrypted DEK with `new-service`, rendering the rest of the code unable to decrypt it.  Because of caching of decrypted DEKs, if this happened you might not even realize it until you launched a new instance of your app.